### PR TITLE
Publishing fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,10 @@
 buildscript {
     repositories {
-        jcenter()
+        gradlePluginPortal()
+        mavenCentral()
     }
     dependencies {
-        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:5.1.4'
+        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:5.2.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/publish/build.gradle
+++ b/publish/build.gradle
@@ -1,4 +1,3 @@
-apply plugin: 'maven'
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.artifactory'
 


### PR DESCRIPTION
After the last update, builds complete successfully up to WebRTC 7151, but we are seeing "Unsupported class file major version 61" when trying the Gradle publishing task. We're likely using Java 17 now, but our gradle version at 6.9.1 is too old. Updating gradle and the artifactory plugin. jcenter() was also deprecated so migrate to gradlePluginPortal() + mavenCentral()