### PR TITLE
Apple Silicon Support And Disabling Siso

### DIFF
--- a/build-final-gn.sh
+++ b/build-final-gn.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -euo pipefail
+
+IMAGE=threema/webrtc-build-tools:latest
+BUILD_ARGS="${WEBRTC_BUILD_ARGS:-symbol_level=1 debuggable_apks=false enable_libaom=false rtc_enable_protobuf=false rtc_include_dav1d_in_internal_decoder_factory=false use_siso=false android_static_analysis=\\\"off\\\"}"
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <revision>"
+    echo "Example: $0 branch-heads/4430"
+    exit 1
+fi
+revision=$1
+
+rm -rf ./out && mkdir -p ./out
+docker run --platform linux/amd64 --rm -v "$(pwd)/out:/out" \
+    $IMAGE /bin/bash -c "
+    set -euo pipefail
+
+    export OUT='/out'
+
+    echo '==> Fetching sources'
+    fetch --nohooks webrtc_android
+
+    echo '==> Change current working directory to src/ of the workspace'
+    cd src
+
+    echo '==> Checking out revision $revision'
+    git checkout $revision
+
+    echo '==> Run gclient sync'
+    gclient sync
+
+    echo '==> Log revision and build args'
+    git log --pretty=fuller HEAD...HEAD^ > \$OUT/revision.txt
+    echo \"BUILD_ARGS: $BUILD_ARGS\" >> \$OUT/build_args.txt
+
+    echo '==> Build directly with GN and Ninja'
+    source build/android/envsetup.sh
+
+    # Build for each Android architecture
+    for arch in armeabi-v7a arm64-v8a x86 x86_64; do
+        echo \"Building for \$arch\"
+        
+        # Convert arch names
+        case \$arch in
+            armeabi-v7a) gn_arch=\"arm\" ;;
+            arm64-v8a) gn_arch=\"arm64\" ;;
+            x86) gn_arch=\"x86\" ;;
+            x86_64) gn_arch=\"x64\" ;;
+        esac
+        
+        # Generate build files
+        gn gen out/\$arch --args=\"target_os=\\\"android\\\" target_cpu=\\\"\$gn_arch\\\" $BUILD_ARGS\"
+        
+        # Build the required targets
+        ninja -C out/\$arch sdk/android:libwebrtc sdk/android:libjingle_peerconnection_so
+    done
+
+    echo '==> Create AAR manually'
+    python3 tools_webrtc/android/build_aar.py --build-dir out --output \$OUT/libwebrtc.aar
+
+    echo 'Done!'
+"

--- a/build-final-gn.sh
+++ b/build-final-gn.sh
@@ -37,8 +37,11 @@ docker run --platform linux/amd64 --rm -v "$(pwd)/out:/out" \
     echo '==> Build directly with GN and Ninja'
     source build/android/envsetup.sh
 
+    # Define Android architectures
+    DEFAULT_ARCHS=(armeabi-v7a arm64-v8a x86 x86_64)
+
     # Build for each Android architecture
-    for arch in armeabi-v7a arm64-v8a x86 x86_64; do
+    for arch in \"\${DEFAULT_ARCHS[@]}\"; do
         echo \"Building for \$arch\"
         
         # Convert arch names

--- a/build-final-gn.sh
+++ b/build-final-gn.sh
@@ -56,7 +56,7 @@ docker run --platform linux/amd64 --rm -v "$(pwd)/out:/out" \
         gn gen out/\$arch --args=\"target_os=\\\"android\\\" target_cpu=\\\"\$gn_arch\\\" $BUILD_ARGS\"
         
         # Build the required targets
-        ninja -C out/\$arch sdk/android:libwebrtc sdk/android:libjingle_peerconnection_so
+        autoninja -C out/\$arch sdk/android:libwebrtc sdk/android:libjingle_peerconnection_so
     done
 
     echo '==> Create AAR manually'

--- a/build-final-gn.sh
+++ b/build-final-gn.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 IMAGE=threema/webrtc-build-tools:latest
-BUILD_ARGS="${WEBRTC_BUILD_ARGS:-symbol_level=1 debuggable_apks=false enable_libaom=false rtc_enable_protobuf=false rtc_include_dav1d_in_internal_decoder_factory=false use_siso=false android_static_analysis=\\\"off\\\"}"
+BUILD_ARGS="${WEBRTC_BUILD_ARGS:-symbol_level=1 debuggable_apks=false enable_libaom=false rtc_enable_protobuf=false rtc_include_dav1d_in_internal_decoder_factory=false use_siso=false android_static_analysis=\\\"off\\\" is_component_build=false rtc_include_tests=false use_goma=false}"
 
 if [ $# -ne 1 ]; then
     echo "Usage: $0 <revision>"

--- a/build-final.sh
+++ b/build-final.sh
@@ -12,7 +12,7 @@ fi
 revision=$1
 
 rm -rf ./out && mkdir -p ./out
-docker run --rm -v "$(pwd)/out:/out" -v "$(pwd)/patches:/patches" \
+docker run --platform linux/amd64 --rm -v "$(pwd)/out:/out" -v "$(pwd)/patches:/patches" \
     $IMAGE /bin/bash -c "
     set -euo pipefail
     shopt -s nullglob

--- a/cli.sh
+++ b/cli.sh
@@ -30,7 +30,7 @@ function build_target {
     target=$1
     build_args=${@:2}
 
-    docker run -it -v ${PWD}/webrtc:/webrtc threema/webrtc-build-tools:latest bash -c "
+    docker run --platform linux/amd64 -it -v ${PWD}/webrtc:/webrtc threema/webrtc-build-tools:latest bash -c "
         set -euo pipefail
         cd src
         gn gen out/android-${target} --args='cc_wrapper=\"ccache\" target_os=\"android\" target_cpu=\"${target}\" ${build_args}'
@@ -73,7 +73,7 @@ case ${1-} in
 
     build-tools)
         echo "Building tools image"
-        docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) \
+        docker build --platform linux/amd64 --build-arg UID=$(id -u) --build-arg GID=$(id -g) \
                      --pull --no-cache -t \
                      threema/webrtc-build-tools:latest build-tools/
         ;;
@@ -89,7 +89,7 @@ case ${1-} in
         # Fetch sources
         mkdir webrtc
         revision=${2:-main}
-        docker run -it -v ${PWD}/webrtc:/webrtc threema/webrtc-build-tools:latest bash -c "
+        docker run --platform linux/amd64 -it -v ${PWD}/webrtc:/webrtc threema/webrtc-build-tools:latest bash -c "
             set -euo pipefail
             echo 'Fetching source files'
             fetch webrtc_android
@@ -112,7 +112,7 @@ case ${1-} in
         (cd webrtc/src && git stash push -u)
 
         # Update sources
-        docker run -it -v ${PWD}/webrtc:/webrtc threema/webrtc-build-tools:latest bash -c "
+        docker run --platform linux/amd64 -it -v ${PWD}/webrtc:/webrtc threema/webrtc-build-tools:latest bash -c "
             set -euo pipefail
             echo 'Updating source files and tracking branches'
             echo 'Note: This will leave all untracked branches untouched!'
@@ -132,7 +132,7 @@ case ${1-} in
         fi
 
         # Sync sources
-        docker run -it -v ${PWD}/webrtc:/webrtc threema/webrtc-build-tools:latest bash -c "
+        docker run --platform linux/amd64 -it -v ${PWD}/webrtc:/webrtc threema/webrtc-build-tools:latest bash -c "
             set -euo pipefail
             echo 'Syncing third party repos and running pre-compile hooks'
             gclient sync -D
@@ -209,7 +209,7 @@ case ${1-} in
         require_tools_image
         
         # Run an interactive shell
-        docker run -it -v ${PWD}/webrtc:/webrtc threema/webrtc-build-tools:latest
+        docker run --platform linux/amd64 -it -v ${PWD}/webrtc:/webrtc threema/webrtc-build-tools:latest
         ;;
 
     *)


### PR DESCRIPTION
Ran into a few issues when trying to compile version 138.0.7204.179 locally on my M1 mac.

macOS 15.5
Docker Desktop 4.43.2

**Rosetta**

When running on an M1 the following error would be thrown:

```rosetta error: failed to open elf at /lib64/ld-linux-x86-64.so.2```

After looking around, it looks like we can fix this by declaring the platform Docker should use in our run and build commands. Setting this to `linux/amd64` appears to fix the issue and I’m assuming that applies to all Apple Silicon machines. I tested this locally and within a Jenkins job (Intel, I believe) and both worked great so I think it’s safe to hardcode.

**Disabling Siso**

Starting with Chromium milestone 138 and branch 7204 there’s a new build system for WebRTC, [Siso](https://chromium.googlesource.com/infra/infra/+/refs/heads/main/go/src/infra/build/siso/). This is a newer build system developed by Google and it’s designed for remote execution and scalability, whereas Ninja is designed for fast incremental builds. Ninja is still widely adopted, so for now I’d like to continue using Ninja until we decide we want to formally adopt Siso.

There is a build argument `use_siso=false` which _should_ allow you to bypass Siso, but it doesn’t work when used within `build_final.sh`. This is because the underlying script `build_aar.py` doesn’t appear to pass this build argument down to its underlying Ninja calls, so effectively the build argument is lost. To get around this issue, I’ve added a variant of `build_final.sh` which calls Ninja directly and passes the `use_siso` build argument through appropriately. After all the architectures are compiled it will then call `build_aar.py` with the `—build-dir` parameter which will tell it where the pre-built artifacts are.

**Static Analysis**

After getting the Siso issue out of the way a new issue popped up:

```
../../sdk/android/api/org/webrtc/RendererCommon.java:130: warning: [FieldCanBeFinal] This field is only assigned during initialization; consider making it final
  private static float BALANCED_VISIBLE_FRACTION = 0.5625f;
```

Apparently, some of the code within WebRTC does not pass static analysis. I went down a little bit of a rabbit hole trying to disable warnings as errors and ran into other issues, but for now I’ve disabled static analysis with the build argument `android_static_analysis=”off”`. If we need to enable static analysis I can continue to look into disabling warnings as errors.