### PR TITLE
Use WebRTC Version With Artifactory

### DIFF
--- a/build-final-gn.sh
+++ b/build-final-gn.sh
@@ -5,11 +5,23 @@ IMAGE=threema/webrtc-build-tools:latest
 BUILD_ARGS="${WEBRTC_BUILD_ARGS:-symbol_level=1 debuggable_apks=false enable_libaom=false rtc_enable_protobuf=false rtc_include_dav1d_in_internal_decoder_factory=false use_siso=false android_static_analysis=\\\"off\\\" is_component_build=false rtc_include_tests=false use_goma=false}"
 
 if [ $# -ne 1 ]; then
-    echo "Usage: $0 <revision>"
-    echo "Example: $0 branch-heads/4430"
+    echo "Usage: $0 <version>"
+    echo "Example: $0 138.0.7204.179"
     exit 1
 fi
-revision=$1
+WEBRTC_VERSION=$1
+echo "WebRTC version: $WEBRTC_VERSION"
+
+# Parse branch from version
+WEBRTC_VERSION_REGEX="[0-9]+\.[0-9]+\.([0-9]+)"
+
+if [[ $WEBRTC_VERSION =~ $WEBRTC_VERSION_REGEX ]]; then
+    WEBRTC_BRANCH=${BASH_REMATCH[1]}
+    echo "WebRTC branch: $WEBRTC_BRANCH"
+else
+    echo "Unable to parse WebRTC branch from version: $WEBRTC_VERSION"
+    exit 1
+fi
 
 rm -rf ./out && mkdir -p ./out
 docker run --platform linux/amd64 --rm -v "$(pwd)/out:/out" \
@@ -24,8 +36,8 @@ docker run --platform linux/amd64 --rm -v "$(pwd)/out:/out" \
     echo '==> Change current working directory to src/ of the workspace'
     cd src
 
-    echo '==> Checking out revision $revision'
-    git checkout $revision
+    echo '==> Checking out revision branch-heads/$WEBRTC_BRANCH'
+    git checkout branch-heads/$WEBRTC_BRANCH
 
     echo '==> Run gclient sync'
     gclient sync

--- a/build-final.sh
+++ b/build-final.sh
@@ -5,11 +5,23 @@ IMAGE=threema/webrtc-build-tools:latest
 BUILD_ARGS="${WEBRTC_BUILD_ARGS:-symbol_level=1 debuggable_apks=false enable_libaom=false rtc_enable_protobuf=false rtc_include_dav1d_in_internal_decoder_factory=false}"
 
 if [ $# -ne 1 ]; then
-    echo "Usage: $0 <revision>"
-    echo "Example: $0 branch-heads/4430"
+    echo "Usage: $0 <version>"
+    echo "Example: $0 138.0.7204.179"
     exit 1
 fi
-revision=$1
+WEBRTC_VERSION=$1
+echo "WebRTC version: $WEBRTC_VERSION"
+
+# Parse branch from version
+WEBRTC_VERSION_REGEX="[0-9]+\.[0-9]+\.([0-9]+)"
+
+if [[ $WEBRTC_VERSION =~ $WEBRTC_VERSION_REGEX ]]; then
+    WEBRTC_BRANCH=${BASH_REMATCH[1]}
+    echo "WebRTC branch: $WEBRTC_BRANCH"
+else
+    echo "Unable to parse WebRTC branch from version: $WEBRTC_VERSION"
+    exit 1
+fi
 
 rm -rf ./out && mkdir -p ./out
 docker run --platform linux/amd64 --rm -v "$(pwd)/out:/out" -v "$(pwd)/patches:/patches" \
@@ -26,8 +38,8 @@ docker run --platform linux/amd64 --rm -v "$(pwd)/out:/out" -v "$(pwd)/patches:/
     echo '==> Change current working directory to src/ of the workspace'
     cd src
 
-    echo '==> Checking out revision $revision'
-    git checkout $revision
+    echo '==> Checking out revision branch-heads/$WEBRTC_BRANCH'
+    git checkout branch-heads/$WEBRTC_BRANCH
 
     echo '==> Run gclient sync'
     gclient sync

--- a/build-final.sh
+++ b/build-final.sh
@@ -12,14 +12,21 @@ fi
 WEBRTC_VERSION=$1
 echo "WebRTC version: $WEBRTC_VERSION"
 
-# Parse branch from version
-WEBRTC_VERSION_REGEX="[0-9]+\.[0-9]+\.([0-9]+)"
+# Pull recent releases, find specified version
+RELEASES_RESPONSE=$(curl -s "https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Android&num=50")
+RELEASES_JSON=$(echo "$RELEASES_RESPONSE" | sed -n 's/.*\({[^{]*"version"[^}]*"'${WEBRTC_VERSION//./\.}'"[^}]*}\).*/\1/p')
 
-if [[ $WEBRTC_VERSION =~ $WEBRTC_VERSION_REGEX ]]; then
-    WEBRTC_BRANCH=${BASH_REMATCH[1]}
-    echo "WebRTC branch: $WEBRTC_BRANCH"
+if [[ -n "$RELEASES_JSON" ]]; then
+    COMMIT_HASH=$(echo "$RELEASES_JSON" | sed -n 's/.*"webrtc":"\([^"]*\)".*/\1/p')
+    
+    if [[ -n "$COMMIT_HASH" ]]; then
+        echo "Commit hash for $WEBRTC_VERSION: $COMMIT_HASH"
+    else
+        echo "Unable to extract webrtc hash from json: $RELEASES_JSON"
+        exit 1
+    fi
 else
-    echo "Unable to parse WebRTC branch from version: $WEBRTC_VERSION"
+    echo "Unable to fetch metadata for version: $WEBRTC_VERSION"
     exit 1
 fi
 
@@ -38,8 +45,8 @@ docker run --platform linux/amd64 --rm -v "$(pwd)/out:/out" -v "$(pwd)/patches:/
     echo '==> Change current working directory to src/ of the workspace'
     cd src
 
-    echo '==> Checking out revision branch-heads/$WEBRTC_BRANCH'
-    git checkout branch-heads/$WEBRTC_BRANCH
+    echo '==> Checking out release $WEBRTC_VERSION'
+    git checkout $COMMIT_HASH
 
     echo '==> Run gclient sync'
     gclient sync

--- a/publish/build.gradle
+++ b/publish/build.gradle
@@ -1,11 +1,9 @@
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.artifactory'
 
-def buildRevision = System.getenv("BUILD_REVISION")
-        ? System.getenv("BUILD_REVISION")
-        : "2999"
-
-version = '1.0.' + buildRevision
+version = System.getenv("WEBRTC_VERSION")
+        ? System.getenv("WEBRTC_VERSION")
+        : "1.0"
 
 configurations {
     aarLocal


### PR DESCRIPTION
Updating the library version that's sent to Artifactory to match the WebRTC version (e.g. `138.0.7204.180`). This should align better with the Chromium releases which you can find here:

https://chromiumdash.appspot.com/releases?platform=Android

The big change is the parameter for `build-final.sh` and `build-final-gn.sh`. You now need to supply the full version instead of just the branch. The script will parse out the branch from the version and pull the corresponding branch head. For example:

```
# before
./build-final-gn.sh branch-heads/7204

# after
./build-final-gn.sh 138.0.7204.180
```

Regarding the Artifactory version, it's now simply passing through the `WEBRTC_VERSION`.