### PR TITLE
Artifactory Publish Fix

### DIFF
--- a/build-final-gn.sh
+++ b/build-final-gn.sh
@@ -21,7 +21,10 @@ import sys, json
 data = json.load(sys.stdin)
 for release in data:
     if release.get('version') == '$WEBRTC_VERSION':
-        print(release.get('webrtc', ''))
+        hashes = release.get('hashes', {})
+        commit = hashes.get('webrtc')
+        if commit:
+            print(commit)
         break
 ")
 

--- a/build-final-gn.sh
+++ b/build-final-gn.sh
@@ -29,6 +29,7 @@ if [[ -n "$COMMIT_HASH" ]]; then
     echo "Commit hash for $WEBRTC_VERSION: $COMMIT_HASH"
 else
     echo "Unable to fetch metadata for version: $WEBRTC_VERSION"
+    echo $RELEASES_RESPONSE
     exit 1
 fi
 

--- a/build-final-gn.sh
+++ b/build-final-gn.sh
@@ -29,7 +29,12 @@ if [[ -n "$COMMIT_HASH" ]]; then
     echo "Commit hash for $WEBRTC_VERSION: $COMMIT_HASH"
 else
     echo "Unable to fetch metadata for version: $WEBRTC_VERSION"
-    echo $RELEASES_RESPONSE
+    echo "Available versions:"
+    echo "$RELEASES_RESPONSE" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for release in data[:10]:
+    print(f\"  {release.get('version', 'N/A')} (milestone {release.get('milestone', 'N/A')})\")" 2>/dev/null || echo "  Failed to parse available versions"
     exit 1
 fi
 

--- a/build-final-gn.sh
+++ b/build-final-gn.sh
@@ -14,17 +14,19 @@ echo "WebRTC version: $WEBRTC_VERSION"
 
 # Pull recent releases, find specified version
 RELEASES_RESPONSE=$(curl -s "https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Android&num=50")
-RELEASES_JSON=$(echo "$RELEASES_RESPONSE" | sed -n 's/.*\({[^{]*"version"[^}]*"'${WEBRTC_VERSION//./\.}'"[^}]*}\).*/\1/p')
 
-if [[ -n "$RELEASES_JSON" ]]; then
-    COMMIT_HASH=$(echo "$RELEASES_JSON" | sed -n 's/.*"webrtc":"\([^"]*\)".*/\1/p')
-    
-    if [[ -n "$COMMIT_HASH" ]]; then
-        echo "Commit hash for $WEBRTC_VERSION: $COMMIT_HASH"
-    else
-        echo "Unable to extract webrtc hash from json: $RELEASES_JSON"
-        exit 1
-    fi
+# Use python to parse JSON properly
+COMMIT_HASH=$(echo "$RELEASES_RESPONSE" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for release in data:
+    if release.get('version') == '$WEBRTC_VERSION':
+        print(release.get('webrtc', ''))
+        break
+")
+
+if [[ -n "$COMMIT_HASH" ]]; then
+    echo "Commit hash for $WEBRTC_VERSION: $COMMIT_HASH"
 else
     echo "Unable to fetch metadata for version: $WEBRTC_VERSION"
     exit 1

--- a/build-final.sh
+++ b/build-final.sh
@@ -21,7 +21,10 @@ import sys, json
 data = json.load(sys.stdin)
 for release in data:
     if release.get('version') == '$WEBRTC_VERSION':
-        print(release.get('webrtc', ''))
+        hashes = release.get('hashes', {})
+        commit = hashes.get('webrtc')
+        if commit:
+            print(commit)
         break
 ")
 
@@ -29,7 +32,12 @@ if [[ -n "$COMMIT_HASH" ]]; then
     echo "Commit hash for $WEBRTC_VERSION: $COMMIT_HASH"
 else
     echo "Unable to fetch metadata for version: $WEBRTC_VERSION"
-    echo $RELEASES_RESPONSE
+    echo "Available versions:"
+    echo "$RELEASES_RESPONSE" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for release in data[:10]:
+    print(f\"  {release.get('version', 'N/A')} (milestone {release.get('milestone', 'N/A')})\")" 2>/dev/null || echo "  Failed to parse available versions"
     exit 1
 fi
 

--- a/build-final.sh
+++ b/build-final.sh
@@ -29,6 +29,7 @@ if [[ -n "$COMMIT_HASH" ]]; then
     echo "Commit hash for $WEBRTC_VERSION: $COMMIT_HASH"
 else
     echo "Unable to fetch metadata for version: $WEBRTC_VERSION"
+    echo $RELEASES_RESPONSE
     exit 1
 fi
 

--- a/build-final.sh
+++ b/build-final.sh
@@ -14,17 +14,19 @@ echo "WebRTC version: $WEBRTC_VERSION"
 
 # Pull recent releases, find specified version
 RELEASES_RESPONSE=$(curl -s "https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Android&num=50")
-RELEASES_JSON=$(echo "$RELEASES_RESPONSE" | sed -n 's/.*\({[^{]*"version"[^}]*"'${WEBRTC_VERSION//./\.}'"[^}]*}\).*/\1/p')
 
-if [[ -n "$RELEASES_JSON" ]]; then
-    COMMIT_HASH=$(echo "$RELEASES_JSON" | sed -n 's/.*"webrtc":"\([^"]*\)".*/\1/p')
-    
-    if [[ -n "$COMMIT_HASH" ]]; then
-        echo "Commit hash for $WEBRTC_VERSION: $COMMIT_HASH"
-    else
-        echo "Unable to extract webrtc hash from json: $RELEASES_JSON"
-        exit 1
-    fi
+# Use python to parse JSON properly
+COMMIT_HASH=$(echo "$RELEASES_RESPONSE" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for release in data:
+    if release.get('version') == '$WEBRTC_VERSION':
+        print(release.get('webrtc', ''))
+        break
+")
+
+if [[ -n "$COMMIT_HASH" ]]; then
+    echo "Commit hash for $WEBRTC_VERSION: $COMMIT_HASH"
 else
     echo "Unable to fetch metadata for version: $WEBRTC_VERSION"
     exit 1

--- a/publish/build.gradle
+++ b/publish/build.gradle
@@ -1,9 +1,11 @@
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.artifactory'
 
-version = System.getenv("WEBRTC_VERSION")
-        ? System.getenv("WEBRTC_VERSION")
-        : "1.0"
+def webrtcVersion = System.getenv("WEBRTC_VERSION")
+if (!webrtcVersion) {
+    throw new GradleException("WEBRTC_VERSION environment variable is required but not set")
+}
+version = webrtcVersion
 
 configurations {
     aarLocal
@@ -22,6 +24,14 @@ publishing {
             version = version
             artifact aarArtifact
         }
+    }
+}
+
+task verifyVersion {
+    doLast {
+        println "WEBRTC_VERSION: ${version}"
+        println "AAR file exists: ${aarFile.exists()}"
+        println "Ready to publish version ${version}"
     }
 }
 


### PR DESCRIPTION
Found a few issues with the previous changes to the published library version that this PR should fix:

1. `WEBRTC_VERSION` wasn't properly getting set in the Jenkins environment from a previous stage which was making it fallback to version `1.0`. This has now been changed to throw a Gradle exception if the version is not found as it should be in the environment. Additionally, if you want to test what version is being used there's a new Gradle task `verifyVersion` which will spit out what version it's seeing.
2. Ran into an issue where the metadata for a build version wasn't found, updated the logic and error reporting to help address the issue. In this case it ends up that a version for iOS was passed in instead of a version for Android so not really a fault of the code here but still an enhancement that helps clarify things.
